### PR TITLE
feat: improve SKILL.md conciseness and add query routing examples

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -384,8 +384,6 @@ query_engine = index.as_query_engine(
 
 **Verify:** Re-run query, check Phoenix shows improved relevance scores (>0.7).
 
-→ **Deep dive:** [references/observability.md#retrieval-failures](references/observability.md#retrieval-failures)
-
 ### Semantic chunking too slow
 
 **Diagnose:**
@@ -409,8 +407,6 @@ critical_nodes = SemanticSplitterNodeParser(...).get_nodes_from_documents(critic
 ```
 
 **Verify:** Re-run with `show_progress=True`, confirm <1s per document.
-
-→ **Deep dive:** [references/ingestion.md#performance-tuning](references/ingestion.md#performance-tuning)
 
 ### Graph extraction producing noise
 
@@ -436,8 +432,6 @@ SchemaLLMPathExtractor(
 
 **Verify:** Re-index, confirm triplet count reduced and relationships are relevant.
 
-→ **Deep dive:** [references/property-graphs.md#extractor-comparison](references/property-graphs.md#extractor-comparison)
-
 ### Workflow step not triggering
 
 **Diagnose:**
@@ -460,8 +454,6 @@ async def my_step(self, ev: MyEvent) -> StopEvent:  # Type hint must be MyEvent
 ```
 
 **Verify:** Verbose output shows `[my_step] Received event: MyEvent`.
-
-→ **Deep dive:** [references/orchestration.md#steps](references/orchestration.md#steps)
 
 ### Phoenix not showing traces
 
@@ -486,8 +478,6 @@ from llama_index.core import VectorStoreIndex
 ```
 
 **Verify:** Make a query, refresh Phoenix UI, trace appears within 5 seconds.
-
-→ **Deep dive:** [references/observability.md#arize-phoenix-integration](references/observability.md#arize-phoenix-integration)
 
 ---
 

--- a/references/context-rag.md
+++ b/references/context-rag.md
@@ -8,6 +8,7 @@ Dynamic query routing, decomposition, and retrieval refinement.
   - [Selector Types](#selector-types)
   - [QueryEngineTool Setup](#queryenginetool-setup)
   - [Router Implementation](#router-implementation)
+  - [Query Routing Examples](#query-routing-examples)
 - [SubQuestionQueryEngine](#subquestionqueryengine)
 - [NodePostprocessors](#nodepostprocessors)
   - [SimilarityPostprocessor](#similaritypostprocessor)
@@ -126,6 +127,17 @@ router = RouterQueryEngine(
 response = router.query("What is this document about?")  # → summary_tool
 response = router.query("What was Q3 revenue?")          # → sql_tool
 ```
+
+### Query Routing Examples
+
+| Input Query | Routed To | Reason |
+|-------------|-----------|--------|
+| "What is this document about?" | `summary_tool` | High-level overview request matches summary description |
+| "What was Q3 revenue?" | `sql_tool` | Specific number query matches structured data description |
+| "List the key themes" | `summary_tool` | Thematic request matches "thematic overviews" |
+| "How many employees joined in 2024?" | `sql_tool` | Count query matches "counts, and database records" |
+| "What date was the contract signed?" | `detail_tool` | Specific date matches "dates, and precise details" |
+| "Summarize the main findings" | `summary_tool` | Summary request matches "high-level summaries" |
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove redundant 'Deep dive' links from troubleshooting section to reduce content overlap with reference files (addresses Writing Style feedback)
- Add explicit input/output query routing examples table to references/context-rag.md showing sample queries and their routing destinations (addresses Utility feedback)

## Grading Results

- **Original Score:** 99/100 (A)
- **New Score:** 99/100 (A) per JSON output

## Issues Addressed

1. **Minor troubleshooting overlap** (Low severity) - Removed redundant deep dive links that duplicated reference content
2. **Missing explicit I/O templates** (Low severity) - Added query routing examples table showing input queries mapped to output engine selections

## Test plan

- [x] Verified SKILL.md changes remove redundant links
- [x] Verified context-rag.md includes new Query Routing Examples table with 6 sample queries
- [x] Table of contents updated to include new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)